### PR TITLE
Update adoptChild to handle values with "special" characters

### DIFF
--- a/component/backend/Helper/Export.php
+++ b/component/backend/Helper/Export.php
@@ -29,7 +29,8 @@ abstract class Export
 	 */
 	public static function adoptChild(SimpleXMLElement &$root, SimpleXMLElement $child)
 	{
-		$node = $root->addChild($child->getName(), (string) $child);
+		$root->{$child->getName()} = (string) $child;
+		$node = $root->{$child->getName()};
 
 		foreach ($child->attributes() as $attr => $value)
 		{


### PR DESCRIPTION
Basically, the [Export helper's `adoptChild` method](https://github.com/akeeba/com_datacompliance/blob/061cbe28b2606eb72bccac7c843b31afaced57b6/component/backend/Helper/Export.php#L30) runs into [this scenario](http://php.net/manual/en/simplexmlelement.addchild.php#112204) if you export data where a field has ampersands in the value (such as if you have a core Joomla user with the French help site saved as their preference, below is a full JSON string which triggers the issue).

```json
{"admin_style":5,"admin_language":"en-GB","language":"en-GB","editor":"codemirror","helpsite":"https:\/\/help.joomla.fr\/index.php?option=com_help&keyref=Help{major}{minor}:{keyref}","timezone":"America\/Chicago"}
```