### PR TITLE
# [LOW] Flash message from consent redirect appears on Joomla MFA pages

### DIFF
--- a/plugins/system/datacompliance/src/Extension/DataCompliance.php
+++ b/plugins/system/datacompliance/src/Extension/DataCompliance.php
@@ -13,7 +13,6 @@ use Akeeba\Component\DataCompliance\Administrator\Table\ConsenttrailsTable;
 use Exception;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryAwareTrait;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -223,10 +222,10 @@ class DataCompliance extends CMSPlugin implements SubscriberInterface
 				]));
 			}
 
-			// Redirect
-			$this->loadLanguage();
-			$message = Text::_('PLG_SYSTEM_DATACOMPLIANCE_MSG_MUSTACCEPT');
-			$this->getApplication()->enqueueMessage($message, 'warning');
+			// Redirect to the consent page. We intentionally do NOT enqueue a flash message here: if Joomla's MFA
+			// plugin intercepts this redirect and sends the user to MFA setup/verification first, any queued message
+			// would persist in the session and appear on the MFA pages — which have no consent form and confuse the
+			// user. The consent page template already contains its own explanatory text.
 			$url = Route::_('index.php?option=com_datacompliance&view=options', false);
 			$this->getApplication()->redirect($url, 307);
 


### PR DESCRIPTION
## Summary

- Removes the `enqueueMessage()` call from the DataCompliance system plugin's consent redirect logic.
- Also removes the now-unused `use Joomla\CMS\Language\Text;` import.

## Problem

When a new user with forced Joomla MFA logs in for the first time, the sequence is:

1. DataCompliance `onAfterRoute` fires → enqueues flash warning → 307 redirects to `com_datacompliance?view=options`
2. On the consent page request, Joomla's `plg_system_multifactorauth` fires and redirects to `com_users?view=methods` (MFA setup). The consent page is **never rendered**, so the flash message is never consumed from the session.
3. The flash message appears on the MFA setup page (`com_users?view=methods`) and possibly the MFA captive page — pages with no consent form — confusing the user.
4. Only after completing MFA does the consent page appear correctly.

Closes #47

## Fix

Remove the `enqueueMessage()` call (and the now-unused `Text` import and `loadLanguage()` call). The redirect itself is sufficient; the consent page template already contains its own detailed explanatory text via `COM_DATACOMPLIANCE_OPTIONS_CONSENT_INFOBLOCK`.

## Test plan

- [ ] New user, forced MFA enabled, no consent record: log in → confirm no DataCompliance warning appears on `com_users?view=methods` or `com_users?view=captive`
- [ ] After completing MFA, confirm redirect to DataCompliance consent page with full consent form
- [ ] Existing user with no pending MFA setup: confirm consent redirect still works correctly
- [ ] Existing user who has already consented: confirm no redirect occurs