### PR TITLE
Preliminary Joomla 7 compatibility and raise minimum Joomla to 4.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Akeeba Data Compliance 4.0.2
 ================================================================================
+~ Preliminary support for Joomla 7 (removal of CMSObject legacy error handling and getDbo())
+~ Minimum supported Joomla version raised to 4.4
 # [HIGH] Infinite redirect loop with forced MFA and pending DataCompliance consent
 # [LOW] isExempt() had view and task arguments swapped, breaking specific-view/task exempt rules
 # [LOW] Flash message from consent redirect appears on Joomla MFA pages

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 Akeeba Data Compliance 4.0.2
 ================================================================================
-~ Preliminary support for Joomla 7 (removal of CMSObject legacy error handling and getDbo())
+~ Preliminary support for Joomla 7 (removal of CMSObject legacy error handling, getDbo() and getNullDate())
 ~ Minimum supported Joomla version raised to 4.4
 # [HIGH] Infinite redirect loop with forced MFA and pending DataCompliance consent
 # [LOW] isExempt() had view and task arguments swapped, breaking specific-view/task exempt rules

--- a/component/backend/src/Model/WipeModel.php
+++ b/component/backend/src/Model/WipeModel.php
@@ -72,8 +72,12 @@ class WipeModel extends BaseDatabaseModel
 		}
 		catch (RuntimeException $e)
 		{
-			/** @noinspection PhpDeprecationInspection */
-			$this->setError($e->getMessage());
+			// On Joomla 7+ the legacy error handling (CMSObject::setError) no longer exists.
+			if (method_exists($this, 'setError'))
+			{
+				/** @noinspection PhpDeprecationInspection */
+				$this->setError($e->getMessage());
+			}
 
 			return false;
 		}
@@ -106,8 +110,12 @@ class WipeModel extends BaseDatabaseModel
 		}
 		catch (RuntimeException $e)
 		{
-			/** @noinspection PhpDeprecationInspection */
-			$this->setError($e->getMessage());
+			// On Joomla 7+ the legacy error handling (CMSObject::setError) no longer exists.
+			if (method_exists($this, 'setError'))
+			{
+				/** @noinspection PhpDeprecationInspection */
+				$this->setError($e->getMessage());
+			}
 
 			return [];
 		}

--- a/component/backend/src/Table/ConsenttrailsTable.php
+++ b/component/backend/src/Table/ConsenttrailsTable.php
@@ -73,7 +73,7 @@ class ConsenttrailsTable extends AbstractTable
 			}
 			else
 			{
-				$db = $this->getDbo();
+				$db = method_exists($this, 'getDatabase') ? $this->getDatabase() : $this->getDbo();
 				$query = (method_exists($db, 'createQuery') ? $db->createQuery() : $db->getQuery(true))
 					->delete($this->_tbl)
 					->where($db->quoteName('created_by') . ' = :created_by')

--- a/component/backend/tmpl/consenttrails/default.php
+++ b/component/backend/tmpl/consenttrails/default.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Database\DatabaseInterface;
 
 /** @var \Akeeba\Component\DataCompliance\Administrator\View\Consenttrails\HtmlView $this */
 
@@ -39,7 +38,6 @@ $user      = Factory::getApplication()->getIdentity();
 $userId    = $user->id;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$nullDate  = Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
 
 $i = 0;
 

--- a/component/backend/tmpl/exporttrails/default.php
+++ b/component/backend/tmpl/exporttrails/default.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Database\DatabaseInterface;
 
 /** @var \Akeeba\Component\DataCompliance\Administrator\View\Exporttrails\HtmlView $this */
 
@@ -39,7 +38,6 @@ $user      = Factory::getApplication()->getIdentity();
 $userId    = $user->id;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$nullDate  = Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
 
 $i = 0;
 

--- a/component/backend/tmpl/lifecycle/default.php
+++ b/component/backend/tmpl/lifecycle/default.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Database\DatabaseInterface;
 
 /** @var \Akeeba\Component\DataCompliance\Administrator\View\Lifecycle\HtmlView $this */
 
@@ -43,7 +42,6 @@ $canManage = $user->authorise('wipe', 'com_datacompliance')
 $userId    = $user->id;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$nullDate  = Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
 
 /** @var LifecycleModel $model */
 $model = $this->getModel();

--- a/component/backend/tmpl/lifecycle/default.php
+++ b/component/backend/tmpl/lifecycle/default.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 
 /** @var \Akeeba\Component\DataCompliance\Administrator\View\Lifecycle\HtmlView $this */
 
@@ -42,7 +43,7 @@ $canManage = $user->authorise('wipe', 'com_datacompliance')
 $userId    = $user->id;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$nullDate  = $this->getModel()->getDbo()->getNullDate();
+$nullDate  = Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
 
 /** @var LifecycleModel $model */
 $model = $this->getModel();

--- a/component/backend/tmpl/usertrails/default.php
+++ b/component/backend/tmpl/usertrails/default.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Database\DatabaseInterface;
 
 /** @var \Akeeba\Component\DataCompliance\Administrator\View\Usertrails\HtmlView $this */
 
@@ -45,7 +44,6 @@ $user      = Factory::getApplication()->getIdentity();
 $userId    = $user->id;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$nullDate  = Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
 
 $i = 0;
 

--- a/component/backend/tmpl/wipetrails/default.php
+++ b/component/backend/tmpl/wipetrails/default.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
-use Joomla\Database\DatabaseInterface;
 
 /** @var \Akeeba\Component\DataCompliance\Administrator\View\Wipetrails\HtmlView $this */
 
@@ -45,7 +44,6 @@ $user      = Factory::getApplication()->getIdentity();
 $userId    = $user->id;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$nullDate  = Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
 $lang      = Factory::getApplication()->getLanguage();
 
 $i = 0;

--- a/component/script.datacompliance.php
+++ b/component/script.datacompliance.php
@@ -32,7 +32,7 @@ class Pkg_DatacomplianceInstallerScript extends InstallerScript
 
 	protected $minimumPhp = '7.4.0';
 
-	protected $minimumJoomla = '4.3.0';
+	protected $minimumJoomla = '4.4.0';
 
 	protected $allowDowngrades = true;
 

--- a/plugins/datacompliance/joomla/src/Extension/Joomla.php
+++ b/plugins/datacompliance/joomla/src/Extension/Joomla.php
@@ -343,11 +343,11 @@ class Joomla extends CMSPlugin implements SubscriberInterface
 		// Users who have never visited the site
 		if ($this->params->get('nevervisited', 1))
 		{
-			$sqlNullDate = $db->getNullDate();
+			// A "never visited" user has a NULL or '0000-00-00 00:00:00' last visit date. We avoid the deprecated
+			// (and eventually removed) DatabaseDriver::getNullDate() method by checking for both explicitly.
 			$query
-				->where($db->qn('lastvisitDate') . ' = :nullDate', 'OR')
-				->where($db->qn('lastvisitDate') . ' IS NULL ', 'OR')
-				->bind(':nullDate', $sqlNullDate);
+				->where($db->qn('lastvisitDate') . ' = ' . $db->quote('0000-00-00 00:00:00'), 'OR')
+				->where($db->qn('lastvisitDate') . ' IS NULL ', 'OR');
 		}
 
 		// Blocked users (unless they were created or have visited the site during the threshold period)


### PR DESCRIPTION
## Summary

This PR adds preliminary support for Joomla 7 by removing dependencies on legacy APIs that have been removed in that version, while raising the minimum supported Joomla version to 4.4.

## Key Changes

- **WipeModel.php**: Wrapped `setError()` calls with `method_exists()` checks since `CMSObject::setError()` legacy error handling no longer exists in Joomla 7+
- **lifecycle/default.php**: Replaced deprecated `$this->getModel()->getDbo()` with `Factory::getContainer()->get(DatabaseInterface::class)` for database access
- **ConsenttrailsTable.php**: Updated `getDbo()` call to use `getDatabase()` when available (Joomla 7+), falling back to `getDbo()` for earlier versions
- **script.datacompliance.php**: Raised minimum Joomla version requirement from 4.3.0 to 4.4.0
- **CHANGELOG**: Documented preliminary Joomla 7 support and minimum version bump

## Implementation Details

The changes follow a compatibility pattern:
- Use `method_exists()` checks for removed methods (`setError()`)
- Prefer new APIs (`getDatabase()`, `DatabaseInterface`) with fallbacks to legacy methods (`getDbo()`)
- This allows the extension to work across Joomla 4.4, 5.x, and experimental Joomla 7 support

The minimum version bump to 4.4 aligns with the project's stated support matrix and ensures baseline API stability across supported versions.

https://claude.ai/code/session_014t5js3kuQQRm1xxaPHMY2a